### PR TITLE
fix: move KAFKA_CONSUMERS_ENABLED out of settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 *
 
+[0.1.2]
+-------
+fix: move KAFKA_CONSUMERS_ENABLED out of settings
+
 [0.1.1]
 -------
 feat: remove edx-toggles

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -2,4 +2,4 @@
 Plugin to handle ecommerce events.
 """
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/events/settings/common.py
+++ b/events/settings/common.py
@@ -3,5 +3,5 @@ Base settings values.
 """
 
 
-def plugin_settings(settings):
-    settings.KAFKA_CONSUMERS_ENABLED = False
+def plugin_settings(settings):  # pylint: disable=unused-argument
+    pass

--- a/events/settings/devstack.py
+++ b/events/settings/devstack.py
@@ -13,4 +13,3 @@ def plugin_settings(settings):
     settings.SCHEMA_REGISTRY_API_SECRET = ''
     settings.KAFKA_API_KEY = ''
     settings.KAFKA_API_SECRET = ''
-    settings.KAFKA_CONSUMERS_ENABLED = True

--- a/events/settings/production.py
+++ b/events/settings/production.py
@@ -3,5 +3,5 @@ Production settings values.
 """
 
 
-def plugin_settings(settings):
-    settings.KAFKA_CONSUMERS_ENABLED = False
+def plugin_settings(settings):  # pylint: disable=unused-argument
+    pass


### PR DESCRIPTION
Move KAFKA_CONSUMERS_ENABLED out of settings so that it can be controlled from ecommerce.